### PR TITLE
v2024.05.13.1

### DIFF
--- a/Fusion PRO and Original Series/CHANGELOG.md
+++ b/Fusion PRO and Original Series/CHANGELOG.md
@@ -1,6 +1,18 @@
 Onefinity Fusion 360 Post Processor Changelog
 =============================================
 
+## 2024-05-13
+
+- Onefinity Fusion 360 Post Processor:
+  - Created release 'v2024.05.15.1' in order to provide direct download of files.
+
+ - Onefinity Fusion 360 Post Processor:
+   - Added new custom property to enable use of an M2 instead of M30 to end the program. 
+   - Retrofited new Autodesk changes to date 2024-03-15 (ensure compliance and inhertage with fusion core component).
+       | Date       | Title                                        | CRC                                      | 
+       |------------|---------------------------------------------------|------------------------------------------|
+       | 2024/03/15 | See Autodesk Comment | [e423e978b3d8d3b198237a2bea9a90752e27c7b1](https://cam.autodesk.com/hsmposts?p=onefinity) |
+
 ## 2022-02-21
  - Onefinity Fusion 360 Post Processor:
    - Added new custom property to enable use of an M2 instead of M30 to end the program. 


### PR DESCRIPTION
Releasing v2024.05.13.1 of 'onefinity community post-processor files for fusion360' in order to provide direct download of files.

Open file section using 'Assets' arrow to download desired file.

Change: Retrofited new Autodesk/Buildbotics changes to date 2024-03-15.